### PR TITLE
feat: add MCP_TOKENS and MCP_LOGS tables

### DIFF
--- a/migrations/ADD_MCP_TOKENS_AND_LOGS.sql
+++ b/migrations/ADD_MCP_TOKENS_AND_LOGS.sql
@@ -1,0 +1,27 @@
+-- depends: ADD_COLS_STANDINGS
+
+CREATE TABLE MCP_TOKENS (
+    id              INT PRIMARY KEY AUTO_INCREMENT,
+    player_id       INT NOT NULL,
+    name            VARCHAR(64) NULL,
+    token_hash      VARCHAR(64) NOT NULL UNIQUE,
+    token_preview   VARCHAR(12) NOT NULL,
+    created_at      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_used_at    DATETIME NULL,
+    revoked_at      DATETIME NULL,
+    INDEX idx_mcp_tokens_player_active (player_id, revoked_at),
+    CONSTRAINT fk_mcp_tokens_player FOREIGN KEY (player_id) REFERENCES PLAYERS(PLAYER_ID)
+);
+
+CREATE TABLE MCP_LOGS (
+    id              INT PRIMARY KEY AUTO_INCREMENT,
+    player_id       INT NOT NULL,
+    token_id        INT NOT NULL,
+    tool_name       VARCHAR(64) NOT NULL,
+    args_summary    VARCHAR(255) NULL,
+    status          ENUM('success', 'error', 'auth_fail') NOT NULL,
+    error_message   VARCHAR(255) NULL,
+    created_at      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_mcp_logs_player_created (player_id, created_at),
+    INDEX idx_mcp_logs_token (token_id)
+);


### PR DESCRIPTION
## Summary
- Adds `MCP_TOKENS` (PAT storage, hashed) and `MCP_LOGS` (audit trail) tables for the new MCP server in fpg-api.
- Indexes: `(token_hash)` unique, `(player_id, revoked_at)` for the "list my active tokens" query, and `(player_id, created_at)` + `(token_id)` on MCP_LOGS.
- FK `MCP_TOKENS.player_id → PLAYERS.PLAYER_ID`.
- Depends on `ADD_COLS_STANDINGS` so yoyo orders it correctly.

## Test plan
- [ ] Apply on testing: GH Actions runs `yoyo apply` on push.
- [ ] Verify both tables exist on testing DB.
- [ ] Verify fpg-api `mcp-server` PR can write into both tables after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)