### PR TITLE
feat(mcp): MCP_TOKENS + OAUTH_* schema migrations

### DIFF
--- a/migrations/ADD_OAUTH_TABLES.sql
+++ b/migrations/ADD_OAUTH_TABLES.sql
@@ -1,0 +1,55 @@
+-- depends: ADD_MCP_TOKENS_AND_LOGS
+
+CREATE TABLE OAUTH_CLIENTS (
+    id                  INT PRIMARY KEY AUTO_INCREMENT,
+    client_id           CHAR(43) NOT NULL UNIQUE,
+    client_secret_hash  CHAR(64) NULL,
+    client_name         VARCHAR(120) NOT NULL,
+    redirect_uris       JSON NOT NULL,
+    registered_at       DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    revoked_at          DATETIME NULL,
+    INDEX idx_oauth_clients_active (client_id, revoked_at)
+);
+
+CREATE TABLE OAUTH_AUTH_CODES (
+    code_hash               CHAR(64) PRIMARY KEY,
+    client_id               CHAR(43) NOT NULL,
+    player_id               INT NOT NULL,
+    redirect_uri            VARCHAR(255) NOT NULL,
+    code_challenge          VARCHAR(128) NOT NULL,
+    code_challenge_method   ENUM('S256','plain') NOT NULL,
+    scope                   VARCHAR(64) NOT NULL,
+    expires_at              DATETIME NOT NULL,
+    consumed_at             DATETIME NULL,
+    INDEX idx_oauth_auth_codes_client (client_id),
+    CONSTRAINT fk_oauth_codes_player FOREIGN KEY (player_id) REFERENCES PLAYERS(PLAYER_ID)
+);
+
+CREATE TABLE OAUTH_ACCESS_TOKENS (
+    id          INT PRIMARY KEY AUTO_INCREMENT,
+    token_hash  CHAR(64) NOT NULL UNIQUE,
+    client_id   CHAR(43) NOT NULL,
+    player_id   INT NOT NULL,
+    scope       VARCHAR(64) NOT NULL,
+    issued_at   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    expires_at  DATETIME NOT NULL,
+    revoked_at  DATETIME NULL,
+    INDEX idx_oauth_access_player_active (player_id, revoked_at),
+    INDEX idx_oauth_access_client (client_id),
+    CONSTRAINT fk_oauth_access_player FOREIGN KEY (player_id) REFERENCES PLAYERS(PLAYER_ID)
+);
+
+CREATE TABLE OAUTH_REFRESH_TOKENS (
+    id              INT PRIMARY KEY AUTO_INCREMENT,
+    token_hash      CHAR(64) NOT NULL UNIQUE,
+    client_id       CHAR(43) NOT NULL,
+    player_id       INT NOT NULL,
+    scope           VARCHAR(64) NOT NULL,
+    issued_at       DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    expires_at      DATETIME NOT NULL,
+    rotated_to_id   INT NULL,
+    revoked_at      DATETIME NULL,
+    INDEX idx_oauth_refresh_player_active (player_id, revoked_at),
+    INDEX idx_oauth_refresh_chain (rotated_to_id),
+    CONSTRAINT fk_oauth_refresh_player FOREIGN KEY (player_id) REFERENCES PLAYERS(PLAYER_ID)
+);


### PR DESCRIPTION
## Summary

Two additive yoyo migrations for the MCP server feature in fpg-api:

- `ADD_MCP_TOKENS_AND_LOGS.sql` — creates `MCP_TOKENS` (Personal Access Tokens used by the Claude Code CLI today) and `MCP_LOGS` (audit log for every MCP tool call). Already applied to DEV_FPG; the PR captures the SQL.
- `ADD_OAUTH_TABLES.sql` — creates the four OAuth tables used by the Phase 1 Authorization Server: `OAUTH_CLIENTS`, `OAUTH_AUTH_CODES`, `OAUTH_ACCESS_TOKENS`, `OAUTH_REFRESH_TOKENS`. Not yet applied — needs `yoyo apply -b` against DEV_FPG before the fpg-api PR is enabled.

## Companion PR

The fpg-api code that uses these tables is in **FPG-APP/fpg_api** PR (link will be added once that PR is open). The fpg-api OAuth subsystem is gated by `MCP_OAUTH_ENABLED=false` so it ships dark — these migrations can be applied at any time without affecting existing traffic.

## Schema notes

All four OAuth tables follow the existing `MCP_TOKENS` conventions:
- `INT PRIMARY KEY AUTO_INCREMENT` surrogate keys (matches `PLAYERS.PLAYER_ID INT` FK target).
- `DATETIME` for timestamps (matches `MCP_TOKENS`).
- `CHAR(43)` for `client_id` (43-char url-safe base64), `CHAR(64)` for SHA-256 hex hashes.
- FK to `PLAYERS(PLAYER_ID)` on every player-scoped table.
- Indexes for the hot lookup paths: `token_hash` UNIQUE, `(player_id, revoked_at)` for active-token lookups, `rotated_to_id` for refresh chain walks.

No ALTERs to existing tables.

## Test plan

- [ ] Run `yoyo apply -b` against DEV_FPG and confirm `SHOW TABLES LIKE 'OAUTH_%'` lists all four.
- [ ] Re-run the existing fpg-api pytest suite against DEV_FPG to confirm no FK/constraint conflicts.
- [ ] After fpg-api PR lands, smoke-test the full OAuth flow against the testing deploy with `MCP_OAUTH_ENABLED=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)