### PR TITLE
feat(mcp): add MCP_LOGS.token_kind column for PAT vs OAuth audit

### DIFF
--- a/migrations/ADD_MCP_LOGS_TOKEN_KIND.sql
+++ b/migrations/ADD_MCP_LOGS_TOKEN_KIND.sql
@@ -1,0 +1,4 @@
+-- depends: ADD_OAUTH_TABLES
+
+ALTER TABLE MCP_LOGS
+  ADD COLUMN token_kind ENUM('pat','oauth') NOT NULL DEFAULT 'pat';


### PR DESCRIPTION
## Summary

- Adds a `token_kind ENUM('pat','oauth') NOT NULL DEFAULT 'pat'` column to `MCP_LOGS`.
- Depends on `ADD_OAUTH_TABLES` (already applied).
- Lets the audit layer in fpg-api distinguish Claude Code (PAT) calls from Claude Desktop / Claude.ai web Connectors (OAuth) calls.

This is the DB half of fpg-api's Phase 2+3+4 MCP work. The `DEFAULT 'pat'` is deliberate: existing `log_mcp_call` callers in fpg-api that don't pass `token_kind=` still write a sensible row (they're all PAT-path).

## Test plan

- [ ] `yoyo list` shows the migration as pending
- [ ] `yoyo apply` against the testing DB succeeds
- [ ] `DESCRIBE MCP_LOGS;` shows the new column
- [ ] After fpg-api `mcp-phase-2` deploys, inserting an OAuth-flow call produces a row with `token_kind='oauth'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)